### PR TITLE
Sphinx theme upgrade

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,13 @@ html_css_files = [
 # documentation.
 #
 html_theme_options = {
+    "github_repository": "https://github.com/IATI/iati-validator-docs",
     "plausible_domain": "validator.iatistandard.org",
+    "languages": {
+        "en": "English",
+        "fr": "French",
+        "es": "Spanish",
+    }
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,12 +24,6 @@ Help & Support
 
  `Get in touch <https://iatistandard.org/en/contact/>`_ with any questions relating to publishing, using or improving IATI data. There is an active community of IATI publishers and users on `IATI Connect <https://iaticonnect.org/data-publishing-cop/stream>`_ 
 
-
-.. toctree::
-   :hidden:
-
-   Home <self>
-
 .. toctree::
    :hidden:
    :titlesonly:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ docutils==0.21.2
     #   sphinx-togglebutton
     #   sphinxcontrib-opendataservices
     #   sphinxcontrib-opendataservices-jsonschema
-iati-sphinx-theme==1.3.0
+iati-sphinx-theme==1.5.1
     # via -r requirements.in
 idna==3.7
     # via requests


### PR DESCRIPTION
- Upgrade to latest version of IATI Sphinx theme, add required config
- Remove link to homepage from table of contents which is now present in the header instead
- Note: The theme itself (i.e. the header and footer) is not yet translated, only the documentation contents

**View the build with functional language switcher at https://docs.validator.iatistandard.org/en/sphinx-theme-upgrade/**